### PR TITLE
Disable exception throwing when position != data pool offset

### DIFF
--- a/src/Lib/VivLib/Containers/VivFile.cs
+++ b/src/Lib/VivLib/Containers/VivFile.cs
@@ -49,7 +49,7 @@ public class VivFile
         }
         if (stream.CanSeek && stream.Position != blobPool)
         {
-            throw new InvalidDataException("Blob pool location mismatch");
+            // TODO: Define actual course of action - Extra bytes after reading the header, but before the data pool (probably for alignment reasons?)
         }
         foreach (var j in fileOffsets.OrderBy(p => p.Value.offset))
         {


### PR DESCRIPTION
This PR disables an exception when the position after reading a VIV header did not match the data pool offset.