### PR TITLE
FCE broken UV fix

### DIFF
--- a/src/App/Vivianne.Wpf/ValueConverters/FcePartToGeometry3dConverter.cs
+++ b/src/App/Vivianne.Wpf/ValueConverters/FcePartToGeometry3dConverter.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Globalization;
+﻿using System.Globalization;
 using System.IO;
 using System.Windows;
 using System.Windows.Media;

--- a/src/App/Vivianne.Wpf/ValueConverters/FcePartToGeometry3dConverter.cs
+++ b/src/App/Vivianne.Wpf/ValueConverters/FcePartToGeometry3dConverter.cs
@@ -1,28 +1,15 @@
 ﻿using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Media3D;
+using TheXDS.MCART.Types.Extensions;
 using TheXDS.MCART.ValueConverters.Base;
 using TheXDS.Vivianne.Models;
 using TheXDS.Vivianne.ViewModels;
 
 namespace TheXDS.Vivianne.ValueConverters;
-
-public class FcePartToMeshGeometryConverter : IOneWayValueConverter<FcePart, MeshGeometry3D>
-{
-    public MeshGeometry3D Convert(FcePart value, object? parameter, CultureInfo? culture)
-    {
-        if (value is null || value.Vertices is null) return null;
-        return new MeshGeometry3D()
-        {
-            Positions = new Point3DCollection(value.Vertices.Select(p => new Point3D(p.Z * -10, p.X * 10, p.Y * 10))),
-            TriangleIndices = new Int32Collection(value.Triangles.SelectMany(p => (int[])[p.I1, p.I2, p.I3])),
-            Normals = new Vector3DCollection(value.Normals.Select(p => new Vector3D(p.Z, p.X, p.Y))),
-            TextureCoordinates = new PointCollection(value.Triangles.SelectMany(p => (Point[])[new Point(p.U1, p.V1), new Point(p.U2, p.V2), new Point(p.U3, p.V3)]))
-        };
-    }
-}
 
 /// <summary>
 /// Implements a value converter that converts a <see cref="RenderTreeState"/>
@@ -30,33 +17,76 @@ public class FcePartToMeshGeometryConverter : IOneWayValueConverter<FcePart, Mes
 /// </summary>
 public class FcePreviewViewModelToModel3DGroupConverter : IOneWayValueConverter<RenderTreeState?, Model3DGroup?>
 {
+    private record class VertexUv(Point3D Vertex, Point Uv, Vector3d Normal);
+
     private const double SizeFactor = 10.0;
 
-    private static Point3D ToPoint3D(Vector3d vert, Vector3d origin)
+    private static MeshGeometry3D ToGeometry(FcePart value, bool flipU, bool flipV)
     {
-        // NFS3 coords system is left handed; with X lengthwise, Y heightwise and Z widthwise.
-        // WPF utilizes right handed coords; X widthwise, Y lenghwise and Z heightwise.
-        return new Point3D((vert.Z + origin.Z) * -SizeFactor, (vert.X + origin.X) * SizeFactor, (vert.Y + origin.Y) * SizeFactor);
-    }
-
-    private static MeshGeometry3D ToGeometry(FcePart value)
-    {
-        var vertex = new (Point3D, Point)[value.Vertices.Length];
-        foreach (var j in value.Triangles)
+        /* This convoluted method has a reason for being
+         * =============================================
+         * 3D models using the FCE file format support per-triangle UV. That
+         * means that the UV data can be defined for each individual triangle,
+         * even if they share vertices. Modern rendering engines moved away
+         * from that, and while they could still support it, this usually
+         * requires some more direct manipulation of the 3D api in use
+         * (DirectX).
+         * 
+         * This is a WPF app, and WPF itself includes a simple yet
+         * easy to use 3D rendering engine, but it's limited to use per-vertex
+         * UV. This means that in order to properly render FCE models that
+         * utilize per-triangle UV mapping, we have to convert from
+         * per-triangle UV to per-vertex UV format. This implies duplicating
+         * vertices and normals just so we can pair that new vertex with its
+         * own UV data, and then we remap the triangle to use the copy.
+         * 
+         * This is not a problem if the FCE file was created in such a way that
+         * any triangle sharing vertices was made to use the exact same UV
+         * coordinates for whichever shared vertices they have.
+         */
+        var vertex = new List<VertexUv?>(new VertexUv[value.Vertices.Length]);
+        const double epsilon = 0.0005;
+        var workingCopy = new Triangle[value.Triangles.Length];
+        for (int i = 0; i < value.Triangles.Length; i++)
         {
+            var j = value.Triangles[i];
+            var uFlip = flipU ? -1 : 1;
+            var vFlip = flipV ? -1 : 1;
             var v1 = value.Vertices[j.I1];
             var v2 = value.Vertices[j.I2];
             var v3 = value.Vertices[j.I3];
-            vertex[j.I1] = (new Point3D(SizeFactor * v1.Z, SizeFactor * v1.X, SizeFactor * v1.Y), new Point(j.U1, -j.V1));
-            vertex[j.I2] = (new Point3D(SizeFactor * v2.Z, SizeFactor * v2.X, SizeFactor * v2.Y), new Point(j.U2, -j.V2));
-            vertex[j.I3] = (new Point3D(SizeFactor * v3.Z, SizeFactor * v3.X, SizeFactor * v3.Y), new Point(j.U3, -j.V3));
+            var vert1 = new Point3D(SizeFactor * (v1.Z + value.Origin.Z), SizeFactor * (v1.X + value.Origin.X), SizeFactor * (v1.Y + value.Origin.Y));
+            var vert2 = new Point3D(SizeFactor * (v2.Z + value.Origin.Z), SizeFactor * (v2.X + value.Origin.X), SizeFactor * (v2.Y + value.Origin.Y));
+            var vert3 = new Point3D(SizeFactor * (v3.Z + value.Origin.Z), SizeFactor * (v3.X + value.Origin.X), SizeFactor * (v3.Y + value.Origin.Y));
+            var uv1 = new Point(uFlip * j.U1, vFlip * j.V1);
+            var uv2 = new Point(uFlip * j.U2, vFlip * j.V2);
+            var uv3 = new Point(uFlip * j.U3, vFlip * j.V3);
+            if (vertex[j.I1] is { Uv: { } testUv1 } && (Math.Abs(testUv1.X - uv1.X) > epsilon || Math.Abs(testUv1.Y - uv1.Y) > epsilon))
+            {
+                vertex.Add(new(vert1, new Point(uv1.X, uv1.Y), value.Normals[j.I1]));
+                j.I1 = vertex.Count - 1;
+            }
+            if (vertex[j.I2] is { Uv: { } testUv2 } && (Math.Abs(testUv2.X - uv2.X) > epsilon || Math.Abs(testUv2.Y - uv2.Y) > epsilon))
+            {
+                vertex.Add(new(vert2, new Point(uv2.X, uv2.Y), value.Normals[j.I2]));
+                j.I2 = vertex.Count - 1;
+            }
+            if (vertex[j.I3] is { Uv: { } testUv3 } && (Math.Abs(testUv3.X - uv3.X) > epsilon || Math.Abs(testUv3.Y - uv3.Y) > epsilon))
+            {
+                vertex.Add(new(vert3, new Point(uv3.X, uv3.Y), value.Normals[j.I3]));
+                j.I3 = vertex.Count - 1;
+            }
+            vertex[j.I1] = new(vert1, uv1, value.Normals[value.Triangles[i].I1]);
+            vertex[j.I2] = new(vert2, uv2, value.Normals[value.Triangles[i].I2]);
+            vertex[j.I3] = new(vert3, uv3, value.Normals[value.Triangles[i].I3]);
+            workingCopy[i] = j;
         }
         return new MeshGeometry3D()
         {
-            Positions = new Point3DCollection(vertex.Select(p => p.Item1)),
-            TriangleIndices = new Int32Collection(value.Triangles.SelectMany(p => (int[])[p.I1, p.I2, p.I3])),
-            Normals = new Vector3DCollection(value.Normals.Select(p => new Vector3D(p.Z, p.X, p.Y))),
-            TextureCoordinates = new PointCollection(vertex.Select(p => p.Item2)),
+            Positions = new Point3DCollection(vertex.Select(p => p?.Vertex ?? default)),
+            TriangleIndices = new Int32Collection(workingCopy.SelectMany(p => (int[])[p.I1, p.I2, p.I3])),
+            Normals = new Vector3DCollection(vertex.Select(p => p?.Normal ?? default).Select(p => new Vector3D(p.Z, p.X, p.Y))),
+            TextureCoordinates = new PointCollection(vertex.Select(p => p?.Uv ?? default)),
         };
     }
 
@@ -64,8 +94,24 @@ public class FcePreviewViewModelToModel3DGroupConverter : IOneWayValueConverter<
     public Model3DGroup? Convert(RenderTreeState? value, object? parameter, CultureInfo? culture)
     {
         if (value is null) return null;
+        Brush? brush;
+        bool flipU, flipV;
+        if (value.Texture is not null)
+        {
+            brush = new RawImageToBrushConverter().Convert(value.Texture, value.SelectedColor, CultureInfo.InvariantCulture);
+            using var ms = new MemoryStream(value.Texture.Take(18).ToArray());
+            using var br = new BinaryReader(ms);
+            var tgaHeader = br.MarshalReadStruct<TargaHeader>();
+            flipU = tgaHeader.ImageInfo.XOrigin != 0;
+            flipV = tgaHeader.ImageInfo.YOrigin == 0; // NFS3 has the V coord flipped by default.
+        }
+        else
+        {
+            brush = Brushes.Gray;
+            flipV = flipU = false;
+        }
 
-        var matte = new DiffuseMaterial(value.Texture is not null ? new RawImageToBrushConverter().Convert(value.Texture, value.SelectedColor, CultureInfo.InvariantCulture) : Brushes.Gray);
+        var matte = new DiffuseMaterial(brush);
         var m1 = new MaterialGroup()
         {
             Children =
@@ -84,7 +130,7 @@ public class FcePreviewViewModelToModel3DGroupConverter : IOneWayValueConverter<
 
         foreach (var j in value.Parts)
         {
-            group.Children.Add(new GeometryModel3D(ToGeometry(j), m1) { BackMaterial = m1 });
+            group.Children.Add(new GeometryModel3D(ToGeometry(j, flipU, flipV), m1) { BackMaterial = m1 });
         }
         return group;
     }

--- a/src/App/Vivianne.Wpf/ValueConverters/RawImageToBrushConverter.cs
+++ b/src/App/Vivianne.Wpf/ValueConverters/RawImageToBrushConverter.cs
@@ -13,6 +13,6 @@ public class RawImageToBrushConverter : RawImageConverterBase, IOneWayValueConve
     /// <inheritdoc/>
     public Brush? Convert(byte[] value, object? parameter, CultureInfo? culture)
     {
-        return GetBitmap(value, parameter as CarColorItem) is { } bmp ? new ImageBrush(bmp) { TileMode = TileMode.Tile } : (Brush?)null;
+        return GetBitmap(value, parameter as CarColorItem) is { } bmp ? new ImageBrush(bmp) { ViewportUnits = BrushMappingMode.Absolute, TileMode = TileMode.Tile } : (Brush?)null;
     }
 }

--- a/src/App/Vivianne.Wpf/ValueConverters/RawImageToBrushConverter.cs
+++ b/src/App/Vivianne.Wpf/ValueConverters/RawImageToBrushConverter.cs
@@ -5,10 +5,14 @@ using TheXDS.Vivianne.ViewModels;
 
 namespace TheXDS.Vivianne.ValueConverters;
 
+/// <summary>
+/// Converts a raw image blob into a <see cref="Brush"/>.
+/// </summary>
 public class RawImageToBrushConverter : RawImageConverterBase, IOneWayValueConverter<byte[], Brush?>
 {
+    /// <inheritdoc/>
     public Brush? Convert(byte[] value, object? parameter, CultureInfo? culture)
     {
-        return GetBitmap(value, parameter as CarColorItem) is { } bmp ? new ImageBrush(bmp) { TileMode = TileMode.Tile} : (Brush?)null;
+        return GetBitmap(value, parameter as CarColorItem) is { } bmp ? new ImageBrush(bmp) { TileMode = TileMode.Tile } : (Brush?)null;
     }
 }

--- a/src/App/Vivianne.Wpf/Views/FcePreviewView.xaml
+++ b/src/App/Vivianne.Wpf/Views/FcePreviewView.xaml
@@ -11,7 +11,6 @@
     Background="{StaticResource DarkBackground}"
     d:DesignHeight="250" d:DesignWidth="400">
     <UserControl.Resources>
-        <valueconverters:FcePartToMeshGeometryConverter x:Key="fce2mesh"/>
         <valueconverters:FcePreviewViewModelToModel3DGroupConverter x:Key="fcevm2mesh"/>
         <valueconverters:LookBackConverter x:Key="lbc"/>
         <valueconverters:DrawingColorToBrushConverter x:Key="dc2bc"/>

--- a/src/App/Vivianne/ViewModels/VivInfoViewModel.cs
+++ b/src/App/Vivianne/ViewModels/VivInfoViewModel.cs
@@ -48,7 +48,6 @@ public class VivInfoViewModel : ViewModel, IStatefulViewModel<VivMainState>
         {
             p.Report(new(c * 100 / State.Viv.Directory.Count, $"Exporting {j.Key}..."));
             await File.WriteAllBytesAsync(Path.Combine(r.Result, j.Key), j.Value);
-            await Task.Delay(2000);
             c++;
         }
     }

--- a/src/Lib/VivLib/Models/ColorMapSpec.cs
+++ b/src/Lib/VivLib/Models/ColorMapSpec.cs
@@ -1,0 +1,26 @@
+﻿using System.Runtime.InteropServices;
+
+namespace TheXDS.Vivianne.Models
+{
+    /// <summary>
+    /// Describes the color map information in a TGA file.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct ColorMapSpec
+    {
+        /// <summary>
+        /// Offset of the color map.
+        /// </summary>
+        public ushort ColorMapOffset;
+
+        /// <summary>
+        /// Number of elements in the color map.
+        /// </summary>
+        public ushort ColorMapSize;
+
+        /// <summary>
+        /// Bits per color for each element of the color map.
+        /// </summary>
+        public byte BitsPerColor;
+    }
+}

--- a/src/Lib/VivLib/Models/ColorMapType.cs
+++ b/src/Lib/VivLib/Models/ColorMapType.cs
@@ -1,0 +1,17 @@
+﻿namespace TheXDS.Vivianne.Models
+{
+    /// <summary>
+    /// Enumerates the existing color map types for a TGA file.
+    /// </summary>
+    public enum ColorMapType : byte
+    {
+        /// <summary>
+        /// Indicates that the image contains no color map.
+        /// </summary>
+        NoColorMap,
+        /// <summary>
+        /// Indicates that the image contains a color map.
+        /// </summary>
+        ColorMap,
+    }
+}

--- a/src/Lib/VivLib/Models/ImageSpec.cs
+++ b/src/Lib/VivLib/Models/ImageSpec.cs
@@ -1,0 +1,41 @@
+﻿using System.Runtime.InteropServices;
+
+namespace TheXDS.Vivianne.Models
+{
+    /// <summary>
+    /// Describes the dimension, origin and format information of the image.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct ImageSpec
+    {
+        /// <summary>
+        /// X origin.
+        /// </summary>
+        public ushort XOrigin;
+
+        /// <summary>
+        /// Y origin.
+        /// </summary>
+        public ushort YOrigin;
+
+        /// <summary>
+        /// Image width.
+        /// </summary>
+        public ushort Width;
+
+        /// <summary>
+        /// Image height.
+        /// </summary>
+        public ushort Height;
+
+        /// <summary>
+        /// Bits per pixel for TrueColor images.
+        /// </summary>
+        public byte BitsPerPixel;
+
+        /// <summary>
+        /// Descriptor that indicates pixel ordering and alpha channel depth.
+        /// </summary>
+        public byte PixelFormatDescriptor;
+    }
+}

--- a/src/Lib/VivLib/Models/TargaHeader.cs
+++ b/src/Lib/VivLib/Models/TargaHeader.cs
@@ -1,0 +1,36 @@
+﻿using System.Runtime.InteropServices;
+
+namespace TheXDS.Vivianne.Models
+{
+    /// <summary>
+    /// Describes the basic header of a TrueVision TGA (Targa) file.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct TargaHeader
+    {
+        /// <summary>
+        /// ID lenght field.
+        /// </summary>
+        public byte IdLength;
+
+        /// <summary>
+        /// Indicates whether or not a color map is present.
+        /// </summary>
+        public ColorMapType ColorMapType;
+
+        /// <summary>
+        /// Indicates the image type.
+        /// </summary>
+        public TargaImageType ImageType;
+
+        /// <summary>
+        /// Contains information on the color map.
+        /// </summary>
+        public ColorMapSpec ColorMapInfo;
+
+        /// <summary>
+        /// Contains information on the image dimensions/origin anbd format.
+        /// </summary>
+        public ImageSpec ImageInfo;
+    }
+}

--- a/src/Lib/VivLib/Models/TargaImageType.cs
+++ b/src/Lib/VivLib/Models/TargaImageType.cs
@@ -1,0 +1,44 @@
+﻿namespace TheXDS.Vivianne.Models
+{
+    /// <summary>
+    /// Enumerates the possible image formats for a TGA file.
+    /// </summary>
+    public enum TargaImageType : byte
+    {
+        /// <summary>
+        /// No image. Would go unused for any valid TGA file.
+        /// </summary>
+        NoImage = 0,
+
+        /// <summary>
+        /// Indexed image. The TGA should include a color map.
+        /// </summary>
+        Indexed = 1,
+
+        /// <summary>
+        /// True color image. The TGA contains RAW pixel data.
+        /// </summary>
+        TrueColor = 2,
+
+        /// <summary>
+        /// Grayscale image. The TGA contains RAW grayscale per-pixel intensity
+        /// data.
+        /// </summary>
+        Grayscale = 3,
+
+        /// <summary>
+        /// Indexed image with RLE compression.
+        /// </summary>
+        RleIndexed = 9,
+
+        /// <summary>
+        /// True color image with RLE compression.
+        /// </summary>
+        RleTrueColor = 10,
+
+        /// <summary>
+        /// Grayscale image with RLE compression.
+        /// </summary>
+        RleGrayscale = 11,
+    }
+}

--- a/src/Lib/VivLib/Resources/Mappings.cs
+++ b/src/Lib/VivLib/Resources/Mappings.cs
@@ -159,13 +159,13 @@ public static class Mappings
     /// </remarks>
     public static IReadOnlyDictionary<FshBlobFormat, Func<object, byte[]>> FshBlobToPixelWriter { get; } = new Dictionary<FshBlobFormat, Func<object, byte[]>>()
     {
-        { FshBlobFormat.Argb32,         c => { var x = (Rgba32)c; return [x.B, x.G, x.R, x.A]; }},
-        { FshBlobFormat.Rgb24,          c => { var x = (Rgb24)c; return [x.B, x.G, x.R]; }},
+        { FshBlobFormat.Argb32,         c => { var x = (Rgba32)c; return [x.R, x.G, x.B, x.A]; }},
+        { FshBlobFormat.Rgb24,          c => { var x = (Rgb24)c; return [x.R, x.G, x.B]; }},
         { FshBlobFormat.Rgb565,         c => { var x = (Bgr565)c; return BitConverter.GetBytes(x.PackedValue); }},
         { FshBlobFormat.Argb1555,       c => { var x = (Bgra5551)c; return BitConverter.GetBytes(x.PackedValue); }},
-        { FshBlobFormat.Palette32,      c => { var x = (Rgba32)c; return [x.B, x.G, x.R, x.A]; }},
-        { FshBlobFormat.Palette24Dos,   c => { var x = (Rgb24)c; return [x.B, x.G, x.R]; }},
-        { FshBlobFormat.Palette24,      c => { var x = (Rgb24)c; return [x.B, x.G, x.R]; }},
+        { FshBlobFormat.Palette32,      c => { var x = (Rgba32)c; return [x.R, x.G, x.B, x.A]; }},
+        { FshBlobFormat.Palette24Dos,   c => { var x = (Rgb24)c; return [x.R, x.G, x.B]; }},
+        { FshBlobFormat.Palette24,      c => { var x = (Rgb24)c; return [x.R, x.G, x.B]; }},
         { FshBlobFormat.Palette16Nfs5,  c => { var x = (Bgr565)c; return BitConverter.GetBytes(x.PackedValue); }},
         { FshBlobFormat.Palette16,      c => { var x = (Bgr565)c; return BitConverter.GetBytes(x.PackedValue); }},
     }.AsReadOnly();


### PR DESCRIPTION
This PR incorporates a set of changes that fix the incorrect UV mapping errors, including the corruption caused by shared vertices with conflicting UV mappings, and material configuration that made WPF use relative texture scaling.