### PR TITLE
Proper loading of FSH files with color palette

### DIFF
--- a/src/App/Vivianne.Common/ViewModels/FshFileEditorLauncher.cs
+++ b/src/App/Vivianne.Common/ViewModels/FshFileEditorLauncher.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using TheXDS.Ganymede.Services;
 using TheXDS.Ganymede.Types;
 using TheXDS.Ganymede.Types.Extensions;
 using TheXDS.MCART.Component;
@@ -9,7 +8,6 @@ using TheXDS.Vivianne.Models;
 using TheXDS.Vivianne.Properties;
 using TheXDS.Vivianne.Resources;
 using TheXDS.Vivianne.Serializers;
-using TheXDS.Vivianne.Tools;
 using TheXDS.Vivianne.ViewModels.Base;
 using St = TheXDS.Vivianne.Resources.Strings.Tools.FshCompressTool;
 using St2 = TheXDS.Vivianne.Resources.Strings.Tools.QfsDecompressTool;
@@ -70,6 +68,6 @@ public class FshFileEditorLauncher() : FileEditorViewModelLauncher<FshEditorStat
     protected override void BeforeSave(FshFile state, string fileExtension)
     {
         base.BeforeSave(state, fileExtension);
-        state.IsCompressed = System.IO.Path.GetExtension(fileExtension).Equals(".qfs", System.StringComparison.InvariantCultureIgnoreCase);
+        state.IsCompressed = Path.GetExtension(fileExtension).Equals(".qfs", System.StringComparison.InvariantCultureIgnoreCase);
     }
 }

--- a/src/App/Vivianne/ValueConverters/FshImageConverter.cs
+++ b/src/App/Vivianne/ValueConverters/FshImageConverter.cs
@@ -31,7 +31,9 @@ public class FshImageConverter : IMultiValueConverter
         {
             Image<Abgr32> i => GetImage(i, FshBlobFormat.Argb32, alpha),
             Image<Bgra32> i => GetImage(i, FshBlobFormat.Argb32, alpha),
+            Image<Rgba32> i => GetImage(i, FshBlobFormat.Argb32, alpha),
             Image<Bgr24> i => ConvertImageToBitmapSource(FshBlobFormat.Rgb24, i),
+            Image<Rgb24> i => ConvertImageToBitmapSource(FshBlobFormat.Rgb24, i),
             Image<Bgr565> i => ConvertImageToBitmapSource(FshBlobFormat.Rgb565, i),
             _ => null
         };

--- a/src/Lib/VivLib/Extensions/FshBlobExtensions.cs
+++ b/src/Lib/VivLib/Extensions/FshBlobExtensions.cs
@@ -31,7 +31,7 @@ public static class FshBlobExtensions
         }
         if (blob.Magic != FshBlobFormat.Indexed8) return null;
         palette ??= LoadPalette(blob.Footer) ?? CreatePalette();
-        return LoadFromIndexedBlob(blob, palette, p => p.ToPixel<Bgra32>());
+        return LoadFromIndexedBlob(blob, palette, p => p.ToPixel<Rgba32>());
     }
 
     /// <summary>


### PR DESCRIPTION
Thir PR includes changes that fix the loading of FSH and WFS files that include a local palette embedded in their footer.

Closes #66 